### PR TITLE
Fix package name in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bitrise-steplib/steps-project-scanner
+module github.com/bitrise-steplib/steps-project-scanner
 
 go 1.15
 


### PR DESCRIPTION
### Changes
Missing prefix added to the package name in `go.mod`.
