### PR TITLE
Update bitrise-init to 5.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.2
 
 require (
-	github.com/bitrise-io/bitrise-init v0.0.0-20250520133318-e1981b5c0db4
+	github.com/bitrise-io/bitrise-init v0.0.0-20250709124904-524f659d5ac2
 	github.com/bitrise-io/go-steputils v1.0.6
 	github.com/bitrise-io/go-utils v1.0.13
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.22

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
-github.com/bitrise-io/bitrise-init v0.0.0-20250520133318-e1981b5c0db4 h1:8zIn58jz+KtVt1W3r3pkZn4pAliSsLKqAwADeWkdmac=
-github.com/bitrise-io/bitrise-init v0.0.0-20250520133318-e1981b5c0db4/go.mod h1:+aSu4EJO5BnsjjGG5nL6fdXciDaJr3EJnlAEw1P1eMU=
+github.com/bitrise-io/bitrise-init v0.0.0-20250709124904-524f659d5ac2 h1:bds4jVwm8suH06sOBBk4ftpLA9js9RSTHMTRzlSpADA=
+github.com/bitrise-io/bitrise-init v0.0.0-20250709124904-524f659d5ac2/go.mod h1:+aSu4EJO5BnsjjGG5nL6fdXciDaJr3EJnlAEw1P1eMU=
 github.com/bitrise-io/bitrise/v2 v2.30.5 h1:ez1NfLMa8OyO4EfHdRvYDjY2og6GAQv8RJczu75nDK8=
 github.com/bitrise-io/bitrise/v2 v2.30.5/go.mod h1:GQv5foBoO8bmyyybHZIEqMeF9vxT9LfJmOASZ6RWKHI=
 github.com/bitrise-io/envman v0.0.0-20230802102824-1300c57d49c4 h1:idT9p2ISMoW5SOz2ow3jWzxVNc4DkNreLeoTk8BGPHg=

--- a/vendor/github.com/bitrise-io/bitrise-init/scanners/reactnative/reactnative.go
+++ b/vendor/github.com/bitrise-io/bitrise-init/scanners/reactnative/reactnative.go
@@ -146,7 +146,9 @@ func getNativeProjects(packageJSONPth, relPackageJSONDir string) (ios.DetectResu
 	}
 	iosProjects.Projects = newIosProjects
 
-	androidProject.RootDirEntry.RelPath = filepath.Join(relPackageJSONDir, androidProject.RootDirEntry.RelPath)
+	if androidProject != nil {
+		androidProject.RootDirEntry.RelPath = filepath.Join(relPackageJSONDir, androidProject.RootDirEntry.RelPath)
+	}
 
 	return iosProjects, androidProject
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/Masterminds/semver/v3
 # github.com/beevik/etree v1.2.0
 ## explicit; go 1.13
 github.com/beevik/etree
-# github.com/bitrise-io/bitrise-init v0.0.0-20250520133318-e1981b5c0db4
+# github.com/bitrise-io/bitrise-init v0.0.0-20250709124904-524f659d5ac2
 ## explicit; go 1.22.0
 github.com/bitrise-io/bitrise-init/analytics
 github.com/bitrise-io/bitrise-init/detectors/direntry


### PR DESCRIPTION
### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR updates  bitrise-init to 5.7.1 to pull a [fix RN scanner's nil pointer dereference](https://github.com/bitrise-io/bitrise-init/pull/290).