### PR TITLE
Pull bitrise-init 5.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/steps-project-scanner
 go 1.25.7
 
 require (
-	github.com/bitrise-io/bitrise-init v0.0.0-20260514122216-d8834310349c
+	github.com/bitrise-io/bitrise-init v0.0.0-20260622165137-67dd158ae0fc
 	github.com/bitrise-io/go-steputils v1.0.6
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
-github.com/bitrise-io/bitrise-init v0.0.0-20260514122216-d8834310349c h1:P6cXZ+QEpUySaB+j7d7nq4OfJk7JTE5bUWLvPLhWCJo=
-github.com/bitrise-io/bitrise-init v0.0.0-20260514122216-d8834310349c/go.mod h1:9AfnzOiTCXqD16/DCB/wvwFifWabUGYhbEmnHUePCpE=
+github.com/bitrise-io/bitrise-init v0.0.0-20260622165137-67dd158ae0fc h1:9AlWnjl7JPh03Y7XRdNhyiyFRQA4tXi7X1KSovQfCkE=
+github.com/bitrise-io/bitrise-init v0.0.0-20260622165137-67dd158ae0fc/go.mod h1:9AfnzOiTCXqD16/DCB/wvwFifWabUGYhbEmnHUePCpE=
 github.com/bitrise-io/bitrise/v2 v2.39.1 h1:Cvxt+xyaMJdjGHWAhAI5om/t8H0HkpEwTpADAYkPDGk=
 github.com/bitrise-io/bitrise/v2 v2.39.1/go.mod h1:CJVf5qRIXUcQsdNz5g5Rsbo3iQUdi9zmUOKZeijQlg8=
 github.com/bitrise-io/envman v0.0.0-20230802102824-1300c57d49c4 h1:idT9p2ISMoW5SOz2ow3jWzxVNc4DkNreLeoTk8BGPHg=

--- a/vendor/github.com/bitrise-io/bitrise-init/scanners/ios/workflow.go
+++ b/vendor/github.com/bitrise-io/bitrise-init/scanners/ios/workflow.go
@@ -11,7 +11,6 @@ const (
 	TestRepetitionModeKey                 = "test_repetition_mode"
 	TestRepetitionModeRetryOnFailureValue = "retry_on_failure"
 	BuildForTestDestinationKey            = "destination"
-	BuildForTestDestinationValue          = "platform=iOS Simulator,name=iPhone 8 Plus,OS=latest"
 	GenericBuildForTestDestinationValue   = "generic/platform=iOS Simulator"
 	AutomaticCodeSigningKey               = "automatic_code_signing"
 	AutomaticCodeSigningValue             = "api-key"
@@ -207,7 +206,7 @@ func addBuildStep(workflow models.WorkflowID, configBuilder *models.ConfigBuilde
 		return
 	}
 
-	configBuilder.AppendStepListItemsTo(workflow, steps.XcodeBuildForTestStepListItem(xcodeBuildForTestStepInputModels()...))
+	configBuilder.AppendStepListItemsTo(workflow, steps.XcodeBuildForTestStepListItem(genericXcodeBuildForTestStepInputModels()...))
 }
 
 func addArchiveStep(workflow models.WorkflowID, configBuilder *models.ConfigBuilderModel, projectType XcodeProjectType, hasAppClip bool, exportMethod string) {
@@ -297,15 +296,6 @@ func baseXcodeStepInputModels() []envmanModels.EnvironmentItemModel {
 func xcodeTestStepInputModels() []envmanModels.EnvironmentItemModel {
 	inputModels := []envmanModels.EnvironmentItemModel{
 		{TestRepetitionModeKey: TestRepetitionModeRetryOnFailureValue},
-		{CacheLevelKey: CacheLevelNone},
-	}
-
-	return append(baseXcodeStepInputModels(), inputModels...)
-}
-
-func xcodeBuildForTestStepInputModels() []envmanModels.EnvironmentItemModel {
-	inputModels := []envmanModels.EnvironmentItemModel{
-		{BuildForTestDestinationKey: BuildForTestDestinationValue},
 		{CacheLevelKey: CacheLevelNone},
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/Masterminds/semver/v3
 # github.com/beevik/etree v1.2.0
 ## explicit; go 1.13
 github.com/beevik/etree
-# github.com/bitrise-io/bitrise-init v0.0.0-20260514122216-d8834310349c
+# github.com/bitrise-io/bitrise-init v0.0.0-20260622165137-67dd158ae0fc
 ## explicit; go 1.25.7
 github.com/bitrise-io/bitrise-init/analytics
 github.com/bitrise-io/bitrise-init/detectors/direntry


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR updates bitrise-init to [version 5.12.1](https://github.com/bitrise-io/bitrise-init/releases/tag/5.12.1), which uses a generic destination for `xcode-build-for-testing` (iPhone 8 is no longer available as a default simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)